### PR TITLE
Fix type issues

### DIFF
--- a/src/Command/ListTaskCommand.php
+++ b/src/Command/ListTaskCommand.php
@@ -33,12 +33,12 @@ class ListTaskCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var int|null $number */
+        /** @var mixed|null $number */
         $number = $input->getOption('number');
         if (null === $number) {
             $criteria = [];
         } else {
-            $criteria = ['number' => $number];
+            $criteria = ['number' => (int) $number];
         }
 
         $limit = 100;

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -80,7 +80,7 @@ class PingStaleIssuesCommand extends Command
             $this->labelApi->addIssueLabel($issue['number'], 'Stalled', $repository);
 
             // add a scheduled task to process this issue again after 2 weeks
-            $this->scheduler->runLater($repository, $issue['number'], Task::ACTION_INFORM_CLOSE_STALE, new \DateTimeImmutable(self::MESSAGE_TWO_AFTER));
+            $this->scheduler->runLater($repository, (int) $issue['number'], Task::ACTION_INFORM_CLOSE_STALE, new \DateTimeImmutable(self::MESSAGE_TWO_AFTER));
         }
 
         return 0;

--- a/src/Command/RunTaskCommand.php
+++ b/src/Command/RunTaskCommand.php
@@ -34,8 +34,7 @@ class RunTaskCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        /** @var int $limit */
-        $limit = $input->getOption('limit');
+        $limit = (int) $input->getOption('limit');
         foreach ($this->repository->getTasksToVerify($limit) as $task) {
             try {
                 $this->taskRunner->run($task);

--- a/src/Service/TaskScheduler.php
+++ b/src/Service/TaskScheduler.php
@@ -22,7 +22,7 @@ class TaskScheduler
         $this->taskRepo = $taskRepo;
     }
 
-    public function runLater(Repository $repository, $number, int $action, \DateTimeImmutable $checkAt)
+    public function runLater(Repository $repository, int $number, int $action, \DateTimeImmutable $checkAt)
     {
         $task = new Task($repository->getFullName(), $number, $action, $checkAt);
         $this->taskRepo->persist($task);

--- a/src/Subscriber/CloseDraftPRSubscriber.php
+++ b/src/Subscriber/CloseDraftPRSubscriber.php
@@ -31,7 +31,7 @@ class CloseDraftPRSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $number = $data['pull_request']['number'];
+        $number = (int) $data['pull_request']['number'];
         $this->issueApi->commentOnIssue($repository, $number, <<<TXT
 Hey!
 

--- a/src/Subscriber/FindReviewerSubscriber.php
+++ b/src/Subscriber/FindReviewerSubscriber.php
@@ -36,7 +36,7 @@ class FindReviewerSubscriber implements EventSubscriberInterface
         $repository = $event->getRepository();
 
         // set scheduled task to run in 20 hours
-        $this->scheduler->runLater($repository, $data['number'], Task::ACTION_SUGGEST_REVIEWER, new \DateTimeImmutable('+20hours'));
+        $this->scheduler->runLater($repository, (int) $data['number'], Task::ACTION_SUGGEST_REVIEWER, new \DateTimeImmutable('+20hours'));
     }
 
     /**


### PR DESCRIPTION
I see this error in the logs: 

> Error thrown while running command "app:task:run". Message: "Argument 1 passed to App\Repository\TaskRepository::getTasksToVerify() must be of the type int, string given, called in /app/src/Command/RunTaskCommand.php on line 39" command="app:task:run"