### PR TITLE
Use postgres as default in .env

### DIFF
--- a/.env
+++ b/.env
@@ -26,10 +26,6 @@ BOT_USERNAME='carsonbot'
 #GITHUB_TOKEN=XXX
 ###< knplabs/github-api ###
 
-###> doctrine/doctrine-bundle ###
-# Format described at https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# For an SQLite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
-# For a PostgreSQL database, use: "postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=11&charset=utf8"
-# IMPORTANT: You MUST configure your server version, either here or in config/packages/doctrine.yaml
-DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
-###< doctrine/doctrine-bundle ###
+DATABASE_URL=postgres://db_user:db_password@127.0.0.1/carsonbot?serverVersion=12&charset=utf8
+#DATABASE_URL=sqlite:///%kernel.project_dir%/var/data.db
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,14 @@ jobs:
             composer-${{ runner.os }}-
             composer-
 
+      - name: Docker
+        run: docker-compose up -d
+
       - name: Download dependencies
         run: composer install --no-interaction --optimize-autoloader
 
       - name: Setup database
-        run: |
-          bin/console doctrine:database:create
-          bin/console doctrine:schema:create
+        run: bin/console doctrine:schema:create
 
       - name: Run tests
         run: ./vendor/bin/phpunit

--- a/config/packages/prod/doctrine.yaml
+++ b/config/packages/prod/doctrine.yaml
@@ -1,9 +1,4 @@
 doctrine:
-    dbal:
-        # Since the real DATABASE_URL is not available when building cache on deployment,
-        # we need to specify these values here: https://github.com/symfony-tools/carsonbot/issues/179
-        driver: pdo_pgsql
-        server_version: '12'
     orm:
         auto_generate_proxy_classes: false
         metadata_cache_driver:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.7'
+
+services:
+    database:
+        # In production, you may want to use a managed database service
+        image: postgres:12-alpine
+        environment:
+            - POSTGRES_DB=carsonbot
+            - POSTGRES_USER=db_user
+            # You should definitely change the password in production
+            - POSTGRES_PASSWORD=db_password
+        volumes:
+            - db-data:/var/lib/postgresql/data:rw
+            # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
+            # - ./docker/db/data:/var/lib/postgresql/data:rw
+        ports:
+            - "5432:5432"
+volumes:
+    db-data: { }


### PR DESCRIPTION
This is related to #179

~~The docker-compose.yml is not really needed. I though it could be helpful for people that want to try.~~

Let's use postgress on CI too. docker-compose.yml is needed now