### PR TITLE
Avoid closing missing translation issues as stale

### DIFF
--- a/src/Api/Issue/GithubIssueApi.php
+++ b/src/Api/Issue/GithubIssueApi.php
@@ -112,7 +112,7 @@ class GithubIssueApi implements IssueApi
 
     public function findStaleIssues(Repository $repository, \DateTimeImmutable $noUpdateAfter): iterable
     {
-        return $this->resultPager->fetchAllLazy($this->searchApi, 'issues', [sprintf('repo:%s is:issue -label:"Keep open" is:open updated:<%s', $repository->getFullName(), $noUpdateAfter->format('Y-m-d')), 'updated', 'desc']);
+        return $this->resultPager->fetchAllLazy($this->searchApi, 'issues', [sprintf('repo:%s is:issue -label:"Keep open" -label:"Missing translations" is:open updated:<%s', $repository->getFullName(), $noUpdateAfter->format('Y-m-d')), 'updated', 'desc']);
     }
 
     public function getUsers(Repository $repository, $issueNumber): array


### PR DESCRIPTION
If those get closed, the next run of carsonbot would create a new one anyway.