### PR TITLE
Fix phpunit deprecation

### DIFF
--- a/tests/Api/Status/GitHubStatusApiTest.php
+++ b/tests/Api/Status/GitHubStatusApiTest.php
@@ -87,20 +87,19 @@ class GitHubStatusApiTest extends TestCase
 
     public function testSetIssueStatusRemovesExcessStatuses()
     {
-        $this->labelsApi->expects($this->at(0))
+        $this->labelsApi->expects(self::once())
             ->method('getIssueLabels')
             ->with(1234)
             ->willReturn(['Bug', 'Status: Needs Review', 'Status: Needs Work']);
 
-        $this->labelsApi->expects($this->at(1))
+        $this->labelsApi->expects($this->exactly(2))
             ->method('removeIssueLabel')
-            ->with(1234, 'Status: Needs Review');
+            ->withConsecutive(
+                [1234, 'Status: Needs Review'],
+                [1234, 'Status: Needs Work']
+            );
 
-        $this->labelsApi->expects($this->at(2))
-            ->method('removeIssueLabel')
-            ->with(1234, 'Status: Needs Work');
-
-        $this->labelsApi->expects($this->at(3))
+        $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')
             ->with(1234, 'Status: Reviewed');
 
@@ -147,13 +146,12 @@ class GitHubStatusApiTest extends TestCase
             ->with(1234)
             ->willReturn(['Bug', 'Status: Needs Review', 'Unconfirmed']);
 
-        $this->labelsApi->expects($this->at(1))
+        $this->labelsApi->expects($this->exactly(2))
             ->method('removeIssueLabel')
-            ->with(1234, 'Status: Needs Review');
-
-        $this->labelsApi->expects($this->at(2))
-            ->method('removeIssueLabel')
-            ->with(1234, 'Unconfirmed');
+            ->withConsecutive(
+                [1234, 'Status: Needs Review'],
+                [1234, 'Unconfirmed']
+            );
 
         $this->labelsApi->expects($this->once())
             ->method('addIssueLabel')


### PR DESCRIPTION
Fix phpunit deprecations

```
root@4a1e0c585181:/var/www/html# ./vendor/bin/phpunit                                                             
PHPUnit 9.5.20 #StandWithUkraine

.........W..W..................................................  63 / 169 ( 37%)
............................................................... 126 / 169 ( 74%)
...........................................                     169 / 169 (100%)

Time: 00:15.272, Memory: 40.50 MB

There were 2 warnings:

1) App\Tests\Api\Status\GitHubStatusApiTest::testSetIssueStatusRemovesExcessStatuses
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.

2) App\Tests\Api\Status\GitHubStatusApiTest::testSetIssueStatusRemovesUnconfirmedWhenBugIsReviewed
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.

```