### PR TITLE
feat(mismatch-branch-description): be more tolerant about version format

### DIFF
--- a/src/Subscriber/MismatchBranchDescriptionSubscriber.php
+++ b/src/Subscriber/MismatchBranchDescriptionSubscriber.php
@@ -89,6 +89,10 @@ TXT
 
         $descriptionBranch = $descriptionBranchParts[2]; // get the version
 
+        if (str_contains($descriptionBranch, '<!--')) {
+            $descriptionBranch = preg_replace('/<!--.*-->/s', '', $descriptionBranch);
+        }
+
         return \trim($descriptionBranch);
     }
 }

--- a/tests/Subscriber/MismatchBranchDescriptionSubscriberTest.php
+++ b/tests/Subscriber/MismatchBranchDescriptionSubscriberTest.php
@@ -157,6 +157,35 @@ TXT;
         $this->assertSame(1234, $responseData['pull_request']);
     }
 
+    public function testOnPullRequestOpenBadBranchFormatWithHtmlComment()
+    {
+        $this->issueApi->expects($this->never())
+            ->method('commentOnIssue');
+
+        $body = <<<TXT
+| Q             | A
+| ------------- | ---
+| Branch?       | 6.2 <!-- see below -->
+| Bug fix?      | yes/no
+TXT;
+
+        $event = new GitHubEvent([
+            'action' => 'opened',
+            'pull_request' => [
+                'number' => 1234,
+                'body' => $body,
+                'base' => [
+                    'ref' => '6.2',
+                ],
+            ],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
+        $responseData = $event->getResponseData();
+
+        $this->assertCount(0, $responseData);
+    }
+
     public function testOnPullRequestOpenBranchNotInTable()
     {
         $this->issueApi->expects($this->never())


### PR DESCRIPTION
Hi,

This is a proposal to make the feature from #207 more tolerant about mistakes when specifying branch in the Symfony's PR template.

E.g when opening https://github.com/symfony/symfony/pull/48451, visually everything was fine but I forgot an HTML comment (which is visually... invisible), which [made Carson a bit angry](https://github.com/symfony/symfony/pull/48451#issuecomment-1336118537) about that :P 
<img width="743" alt="image" src="https://user-images.githubusercontent.com/2103975/205449405-a292f695-e3b5-4c3e-9813-9659434c904f.png">


Since maintainers look for the HTML-rendered table and not for the Markdown-source table, I think it could be nice to remove HTML comments when checking for the base branch.

WDYT?
Thanks
