### PR TITLE
Improve Mismatch branch when there is markdown comment

### DIFF
--- a/src/Subscriber/MismatchBranchDescriptionSubscriber.php
+++ b/src/Subscriber/MismatchBranchDescriptionSubscriber.php
@@ -72,13 +72,14 @@ TXT
     private function extractDescriptionBranchFromBody(string $body): ?string
     {
         $s = new UnicodeString($body);
+        $bodyWithoutComment = $s->replaceMatches('/<!--\s*.*\s*-->/', '');
 
         // @see symfony/symfony/.github/PULL_REQUEST_TEMPLATE.md
-        if (!$s->containsAny('Branch?')) {
+        if (!$bodyWithoutComment->containsAny('Branch?')) {
             return null;
         }
 
-        $rowsDescriptionBranch = $s->match('/.*Branch.*/');
+        $rowsDescriptionBranch = $bodyWithoutComment->match('/.*Branch.*/');
 
         $rowDescriptionBranch = $rowsDescriptionBranch[0]; // row matching
 

--- a/tests/Controller/WebhookControllerTest.php
+++ b/tests/Controller/WebhookControllerTest.php
@@ -87,7 +87,7 @@ class WebhookControllerTest extends WebTestCase
             'On pull request opened with target branch' => [
                 'pull_request',
                 'pull_request.opened_target_branch.json',
-                ['pull_request' => 3, 'status_change' => 'needs_review', 'pr_labels' => ['Bug'], 'milestone' => '4.4', 'approved_run' => true],
+                ['pull_request' => 3, 'status_change' => 'needs_review', 'pr_labels' => ['Bug'], 'milestone' => '4.4', 'unsupported_branch' => '4.4', 'approved_run' => true],
             ],
             'On issue labeled bug' => [
                 'issues',

--- a/tests/Subscriber/MismatchBranchDescriptionSubscriberTest.php
+++ b/tests/Subscriber/MismatchBranchDescriptionSubscriberTest.php
@@ -69,6 +69,35 @@ TXT;
         $this->assertCount(0, $responseData);
     }
 
+    public function testOnPullRequestOpenMatchWithComment()
+    {
+        $this->issueApi->expects($this->never())
+            ->method('commentOnIssue');
+
+        $body = <<<TXT
+| Q             | A
+| ------------- | ---
+| Branch?       | 6.2 <!-- see below -->
+| Bug fix?      | yes/no
+TXT;
+
+        $event = new GitHubEvent([
+            'action' => 'opened',
+            'pull_request' => [
+                'number' => 1234,
+                'body' => $body,
+                'base' => [
+                    'ref' => '6.2',
+                ],
+            ],
+        ], $this->repository);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
+        $responseData = $event->getResponseData();
+
+        $this->assertCount(0, $responseData);
+    }
+
     public function testOnPullRequestOpenNotMatch()
     {
         $this->issueApi->expects($this->once())


### PR DESCRIPTION
Sometime, contributors don't remove all the line and  keep markdown comment (default in MR template)

```
| Q             | A
| ------------- | ---
| Branch?       | 6.2 <!-- see below -->
| Bug fix?      | yes/no
```

This PR take care of comments and  no publish in this cas

Examples:
https://github.com/symfony/symfony/pull/48451#issuecomment-1336118537
https://github.com/symfony/symfony/pull/48447#issuecomment-1335861801