### PR TITLE
Trim whitespace better

### DIFF
--- a/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
+++ b/src/Subscriber/AutoUpdateTitleWithLabelSubscriber.php
@@ -76,8 +76,11 @@ class AutoUpdateTitleWithLabelSubscriber implements EventSubscriberInterface
             $prPrefix .= '['.$label.']';
         }
 
+        // Clean string from all HTML chars and remove whitespace at the beginning
+        $prTitle = preg_replace('@^[\h\s]+@u', '', html_entity_decode($prTitle));
+
         // Add back labels
-        $prTitle = trim($prPrefix.' '.trim(str_replace('&nbsp;', '', $prTitle)));
+        $prTitle = trim($prPrefix.' '.trim($prTitle));
         if ($originalTitle === $prTitle) {
             return;
         }

--- a/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
+++ b/tests/Subscriber/AutoUpdateTitleWithLabelSubscriberTest.php
@@ -112,4 +112,21 @@ class AutoUpdateTitleWithLabelSubscriberTest extends TestCase
         $this->assertSame(1234, $responseData['pull_request']);
         $this->assertSame('[Console] [Random] Foo normal title', $responseData['new_title']);
     }
+
+    public function testExtraBlankSpace()
+    {
+        $event = new GitHubEvent(['action' => 'labeled', 'number' => 57753, 'pull_request' => []], $this->repository);
+        $this->pullRequestApi->method('show')->willReturn([
+                'title' => '[ErrorHandler]&nbsp;restrict the maximum length of the X-Debug-Exception header',
+                'labels' => [
+                    ['name' => 'ErrorHandler', 'color' => 'dddddd'],
+                ],
+            ]);
+
+        $this->dispatcher->dispatch($event, GitHubEvents::PULL_REQUEST);
+        $responseData = $event->getResponseData();
+        $this->assertCount(2, $responseData);
+        $this->assertSame(57753, $responseData['pull_request']);
+        $this->assertSame('[ErrorHandler] restrict the maximum length of the X-Debug-Exception header', $responseData['new_title']);
+    }
 }


### PR DESCRIPTION
We still see whitespace characters in titles. Example: https://github.com/symfony/symfony/pull/57753#event-13537603748

We did an attempt to fix it in #223. 

I suspect we have some HTML characters, so I convert them to strings, then do a more aggressive trim with regex. 

