### PR TITLE
[CI] Bump some actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload log file
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test.log
           path: var/log/test.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v3
 
       - name: PHPStan
         run: phpstan analyze --no-progress --error-format=checkstyle | cs2pr
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v3
 
       - name: Psalm
         run: psalm --no-progress --output-format=github

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
           tools: phpstan:1.10, cs2pr
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download dependencies
         uses: ramsey/composer-install@v1
@@ -41,7 +41,7 @@ jobs:
           tools: php-cs-fixer:3.42, cs2pr
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: PHP-CS-Fixer
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
@@ -58,7 +58,7 @@ jobs:
           tools: vimeo/psalm:5.18.0
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download dependencies
         uses: ramsey/composer-install@v1


### PR DESCRIPTION
Some checks are failing in #237, because the user version of `actions/upload-artifact` is outdated. 

I took the opportunity to update other actions.