### PR TITLE
Fix Doctrine ORM deprecations

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -8,6 +8,8 @@ doctrine:
     orm:
         auto_generate_proxy_classes: true
         naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        report_fields_where_declared: true
+        enable_lazy_ghost_objects: true
         auto_mapping: true
         mappings:
             App:


### PR DESCRIPTION
This enables the new behaviors of the ORM to avoid getting deprecation warnings.