### PR TITLE
Add support for "Documentation" label

### DIFF
--- a/src/Api/Issue/IssueType.php
+++ b/src/Api/Issue/IssueType.php
@@ -10,4 +10,5 @@ class IssueType
     public const FEATURE = 'Feature';
     public const UNKNOWN = 'Unknown';
     public const RFC = 'RFC';
+    public const DOCUMENTATION = 'Documentation';
 }

--- a/src/Command/PingStaleIssuesCommand.php
+++ b/src/Command/PingStaleIssuesCommand.php
@@ -95,6 +95,7 @@ class PingStaleIssuesCommand extends Command
             IssueType::FEATURE => false,
             IssueType::BUG => false,
             IssueType::RFC => false,
+            IssueType::DOCUMENTATION => false,
         ];
 
         foreach ($issue['labels'] as $label) {

--- a/src/Subscriber/AutoLabelFromContentSubscriber.php
+++ b/src/Subscriber/AutoLabelFromContentSubscriber.php
@@ -40,7 +40,7 @@ class AutoLabelFromContentSubscriber implements EventSubscriberInterface
             $prLabels[] = $label;
         }
 
-        // the PR body usually indicates if this is a Bug, Feature, BC Break or Deprecation
+        // the PR body usually indicates if this is a Bug, Feature, BC Break, Deprecation or Documentation
         if (preg_match('/\|\s*Bug fix\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
             $prLabels[] = 'Bug';
         }
@@ -52,6 +52,9 @@ class AutoLabelFromContentSubscriber implements EventSubscriberInterface
         }
         if (preg_match('/\|\s*Deprecations\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
             $prLabels[] = 'Deprecation';
+        }
+        if (preg_match('/\|\s*Documentation\?\s*\|\s*yes\s*/i', $prBody, $matches)) {
+            $prLabels[] = 'Documentation';
         }
 
         $this->labelsApi->addIssueLabels($prNumber, $prLabels, $repository);


### PR DESCRIPTION
Unlike Symfony, the Symfony UX documentation(s) are located in the same repository. 
A few months ago we added the label `Documentation` (previously `docs`) and `Documentation?` (previously `Docs?`) in the PR template, which helps us for triage.

Today, I would like the label `Documentation` to be automatically added to the PR when necessary.